### PR TITLE
fix : mainposter, model domain and some problem

### DIFF
--- a/controller/CMovie.js
+++ b/controller/CMovie.js
@@ -64,7 +64,7 @@ const errorHandler = (statusCode, res, msg) => {
   switch (statusCode) {
     case 400:
       console.error('잘못된 요청:', msg);
-      res.status(statusCode).json({ message: msg || '잘못된 요청입니다.' });
+      res.status(statusCode).render('404',{ message: msg || '잘못된 요청입니다.' });
       break;
     case 404:
       console.error('오류 발생:', msg);
@@ -72,11 +72,11 @@ const errorHandler = (statusCode, res, msg) => {
       break;
     case 500:
       console.error('서버 오류 발생:', msg);
-      res.status(statusCode).json({ message: msg || '서버 오류가 발생했습니다.' });
+      res.status(statusCode).render('404',{ message: msg || '서버 오류가 발생했습니다.' });
       break;
     default:
       console.error('알 수 없는 오류 발생:', msg);
-      res.status(500).json({ message: '알 수 없는 오류가 발생했습니다.' });
+      res.status(500).render('404',{ message: '알 수 없는 오류가 발생했습니다.' });
       break;
   }
 };

--- a/model/movieModel.js
+++ b/model/movieModel.js
@@ -7,16 +7,16 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false
     },
     movieTitle: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(150),
       allowNull: false,
       unique: true
     },
     posterUrl: {
-      type: DataTypes.STRING(300),
+      type: DataTypes.STRING(400),
       allowNull: true
     },
     vodUrl: {
-      type: DataTypes.STRING(300),
+      type: DataTypes.STRING(400),
       allowNull: true
     },
     reviewMovieRating: {
@@ -24,7 +24,7 @@ module.exports = (sequelize, DataTypes) => {
       defaultValue: 0
     },
     movieSynopsys: {
-      type: DataTypes.STRING(2000),
+      type: DataTypes.STRING(3000),
       allowNull: true
     },
     moviereleaseDate: {
@@ -40,7 +40,7 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: true
     },
     movieCast: {
-      type: DataTypes.STRING(200),
+      type: DataTypes.STRING(400),
       allowNull: true
     }
   }, {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -189,7 +189,8 @@ function dynamicSlides(url, sectionClass, movieData, swiperWrapper) {
 
   const image = document.createElement('img');
   image.src = url;
-  image.alt = 'poster';
+  image.alt = alt="포스터 이미지" 
+  image.setAttribute('onerror',"this.onerror=null; this.src='/img/sample_poster.png';");
   image.id = movieData.movieId;
   
   cardContent.appendChild(image);

--- a/public/js/review.js
+++ b/public/js/review.js
@@ -3,7 +3,7 @@
 // 리뷰 등록 버튼 postReview()
 let nowPage = 0;
 
-const targerE = document.querySelector(".trailer_box");
+const targerE = document.querySelector(".info_container");
 const targerId = targerE.id;
 
 // 리뷰 모달 버튼

--- a/views/review.ejs
+++ b/views/review.ejs
@@ -18,14 +18,14 @@
   <%- include('partials/components/navbar') %>
   <main id="page_container">
     <% if(data.vodUrl && data.vodUrl !== '') { %>
-      <div class="trailer_box" id="<%= data.movieId%>">
+      <div class="trailer_box">
         <video src="https://www.kmdb.or.kr/trailer/play/<%= data.vodUrl %>" autoplay="" muted="" loop=""></video>
       </div>
     <% } %>
     <div id="movie_info_container">
 
   
-      <section class="info_container">
+      <section class="info_container" id="<%= data.movieId%>">
         <article class="sub_info_box">
           <div class="detail_info_box">
             <div class="movie_title">


### PR DESCRIPTION
처리할 수있는 에러는 404 로 가랏!
모델 도메인들 조금만 더 크게..?
메인페이지의 중앙에 포스터가 없는 영화에 리뷰가 달리는 경우 대체이미지를 설정해봤습니다.


기존의 영화 상세 페이지에서 movieId 를받아오는 방법은 요소의 일부의 id에 movieId를 숨겨놓아 그것을 찾아오는 방식이었습니다.
vod가 없는 경우 불필요한 공간을 서버 사이드에서 렌더링하지 않게 하면서 movieId 가 없어지는 경우가 생기고 리뷰를 작성할 수 없는 경우가 생겨서 
위치를 조금 바꿔보았습니다.